### PR TITLE
Enable the monitoring/analytics agent by default

### DIFF
--- a/library/examples/allOptions.groovy
+++ b/library/examples/allOptions.groovy
@@ -94,7 +94,8 @@ muleDeploy {
             staticIpEnabled true
             objectStoreV2Enabled false
         }
-        analyticsAgentEnabled true
+        // this is true by default so have to specify false to NOT set the property
+        analyticsAgentEnabled false
         file 'path/to/file.jar'
         cryptoKey 'theKey'
         autoDiscovery {

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/models/CloudhubDeploymentRequest.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/models/CloudhubDeploymentRequest.groovy
@@ -84,7 +84,7 @@ class CloudhubDeploymentRequest extends FileBasedAppDeploymentRequest {
                               String appVersion = null,
                               Map<String, String> appProperties = [:],
                               Map<String, String> otherCloudHubProperties = [:],
-                              boolean analyticsAgentEnabled = false) {
+                              boolean analyticsAgentEnabled = true) {
         this.file = file
         this.environment = environment
         this.appName = appName ?: parsedPomProperties.artifactId

--- a/library/src/main/java/com/avioconsulting/mule/deployment/dsl/CloudhubContext.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/dsl/CloudhubContext.groovy
@@ -4,7 +4,8 @@ import com.avioconsulting.mule.deployment.api.models.CloudhubDeploymentRequest
 
 class CloudhubContext extends BaseContext {
     String environment, applicationName, appVersion, file, cryptoKey, cloudHubAppPrefix
-    boolean analyticsAgentEnabled
+    // make API visualizer, etc. more easy by default
+    boolean analyticsAgentEnabled = true
     private WorkerSpecContext workerSpecs = new WorkerSpecContext()
     private AutodiscoveryContext autoDiscovery = new AutodiscoveryContext()
     Map<String, String> appProperties = [:]

--- a/library/src/test/java/com/avioconsulting/mule/deployment/DeployerTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/DeployerTest.groovy
@@ -216,11 +216,12 @@ class DeployerTest {
         }
         assertThat deployedChApps[0].cloudhubAppInfo.properties,
                    is(equalTo([
-                           env                              : 'dev',
-                           'auto-discovery.api-id'          : 'api1234',
-                           'crypto.key'                     : 'theKey',
-                           'anypoint.platform.client_id'    : 'theClientId',
-                           'anypoint.platform.client_secret': 'theSecret'
+                           env                                               : 'dev',
+                           'auto-discovery.api-id'                           : 'api1234',
+                           'crypto.key'                                      : 'theKey',
+                           'anypoint.platform.client_id'                     : 'theClientId',
+                           'anypoint.platform.client_secret'                 : 'theSecret',
+                           'anypoint.platform.config.analytics.agent.enabled': true
                    ]))
         assertThat designCenterSyncs.size(),
                    is(equalTo(1))

--- a/library/src/test/java/com/avioconsulting/mule/deployment/api/models/CloudhubDeploymentRequestTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/api/models/CloudhubDeploymentRequestTest.groovy
@@ -156,10 +156,11 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                            objectStoreV1            : false,
                            persistentQueues         : false,
                            properties               : [
-                                   env                              : 'dev',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret'
+                                   env                                               : 'dev',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true
                            ]
                    ]))
     }
@@ -205,12 +206,13 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                            objectStoreV1            : false,
                            persistentQueues         : false,
                            properties               : [
-                                   env                              : 'dev',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret',
-                                   prop1                            : 'foo',
-                                   prop2                            : 'bar'
+                                   env                                               : 'dev',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true,
+                                   prop1                                             : 'foo',
+                                   prop2                                             : 'bar'
                            ]
 
                    ]))
@@ -254,10 +256,11 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                            objectStoreV1            : false,
                            persistentQueues         : true,
                            properties               : [
-                                   env                              : 'dev',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret'
+                                   env                                               : 'dev',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true
                            ]
                    ]))
     }
@@ -305,10 +308,11 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                            objectStoreV1            : false,
                            persistentQueues         : true,
                            properties               : [
-                                   env                              : 'TST',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret'
+                                   env                                               : 'TST',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true
                            ]
                    ]))
     }
@@ -353,10 +357,11 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                            objectStoreV1            : false,
                            persistentQueues         : true,
                            properties               : [
-                                   env                              : 'dev',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret'
+                                   env                                               : 'dev',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true
                            ]
                    ]))
     }
@@ -405,12 +410,13 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                            objectStoreV1            : false,
                            persistentQueues         : true,
                            properties               : [
-                                   env                              : 'TST',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret',
-                                   prop1                            : 'foo',
-                                   prop2                            : 'bar'
+                                   env                                               : 'TST',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true,
+                                   prop1                                             : 'foo',
+                                   prop2                                             : 'bar'
                            ]
                    ]))
     }
@@ -450,10 +456,11 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                            objectStoreV1            : false,
                            persistentQueues         : false,
                            properties               : [
-                                   env                              : 'dev',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret'
+                                   env                                               : 'dev',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true
                            ]
 
                    ]))
@@ -481,7 +488,7 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                                                     null,
                                                     [:],
                                                     [:],
-                                                    true)
+                                                    false)
         // act
         def appInfo = request.getCloudhubAppInfo()
 
@@ -505,11 +512,10 @@ class CloudhubDeploymentRequestTest implements MavenInvoke {
                            objectStoreV1            : true,
                            persistentQueues         : false,
                            properties               : [
-                                   env                                               : 'dev',
-                                   'crypto.key'                                      : 'theKey',
-                                   'anypoint.platform.client_id'                     : 'theClientId',
-                                   'anypoint.platform.client_secret'                 : 'theSecret',
-                                   'anypoint.platform.config.analytics.agent.enabled': true
+                                   env                              : 'dev',
+                                   'crypto.key'                     : 'theKey',
+                                   'anypoint.platform.client_id'    : 'theClientId',
+                                   'anypoint.platform.client_secret': 'theSecret'
                            ]
                    ]))
     }

--- a/library/src/test/java/com/avioconsulting/mule/deployment/dsl/CloudhubContextTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/dsl/CloudhubContextTest.groovy
@@ -61,6 +61,8 @@ class CloudhubContextTest implements MavenInvoke {
                 assertThat objectStoreV2Enabled,
                            is(equalTo(true))
             }
+            assertThat analyticsAgentEnabled,
+                       is(equalTo(true))
             assertThat file,
                        is(equalTo(builtFile))
             assertThat cryptoKey,
@@ -138,7 +140,7 @@ class CloudhubContextTest implements MavenInvoke {
                 staticIpEnabled true
                 objectStoreV2Enabled false
             }
-            analyticsAgentEnabled true
+            analyticsAgentEnabled false
             file 'path/to/file.jar'
             cryptoKey 'theKey'
             autoDiscovery {
@@ -189,7 +191,7 @@ class CloudhubContextTest implements MavenInvoke {
                            is(equalTo(false))
             }
             assertThat analyticsAgentEnabled,
-                       is(equalTo(true))
+                       is(equalTo(false))
             assertThat file,
                        is(equalTo(new File('path/to/file.jar')))
             assertThat cryptoKey,

--- a/library/src/test/java/com/avioconsulting/mule/deployment/internal/subdeployers/CloudHubDeployerTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/internal/subdeployers/CloudHubDeployerTest.groovy
@@ -155,11 +155,12 @@ class CloudHubDeployerTest extends BaseTest {
                            loggingCustomLog4JEnabled: false,
                            persistentQueues         : false,
                            properties               : [
-                                   env                              : 'dev',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret',
-                                   'the.auto.disc.prop'             : '1234'
+                                   env                                               : 'dev',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true,
+                                   'the.auto.disc.prop'                              : '1234'
                            ]
                    ]))
         assertThat rawBody,
@@ -258,10 +259,11 @@ class CloudHubDeployerTest extends BaseTest {
                            loggingCustomLog4JEnabled: false,
                            persistentQueues         : false,
                            properties               : [
-                                   env                              : 'dev',
-                                   'crypto.key'                     : 'theKey',
-                                   'anypoint.platform.client_id'    : 'theClientId',
-                                   'anypoint.platform.client_secret': 'theSecret'
+                                   env                                               : 'dev',
+                                   'crypto.key'                                      : 'theKey',
+                                   'anypoint.platform.client_id'                     : 'theClientId',
+                                   'anypoint.platform.client_secret'                 : 'theSecret',
+                                   'anypoint.platform.config.analytics.agent.enabled': true
                            ]
                    ]))
         assertThat rawBody,


### PR DESCRIPTION
Otherwise, every deployment turns this off because the property goes away