### PR TITLE
Fix bug with exchange module ignore

### DIFF
--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/models/FileBasedAppDeploymentRequest.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/models/FileBasedAppDeploymentRequest.groovy
@@ -18,15 +18,20 @@ abstract class FileBasedAppDeploymentRequest {
             '.designer.json'
     ]
 
-    static boolean isIgnored(Path something) {
+    static List<String> IGNORE_DC_FILES_EXCEPT_EXCHANGE = IGNORE_DC_FILES - ['exchange_modules']
+
+    static boolean isIgnored(Path something,
+                             boolean ignoreExchange = true) {
         def parent = something.parent
+        def list = ignoreExchange ? IGNORE_DC_FILES : IGNORE_DC_FILES_EXCEPT_EXCHANGE
         if (parent) {
-            if (IGNORE_DC_FILES.contains(parent.toString())) {
+            if (list.contains(parent.toString())) {
                 return true
             }
-            return isIgnored(parent)
+            return isIgnored(parent,
+                             ignoreExchange)
         }
-        return IGNORE_DC_FILES.contains(something.toString())
+        return list.contains(something.toString())
     }
 
     @Lazy
@@ -72,7 +77,8 @@ abstract class FileBasedAppDeploymentRequest {
 
     abstract String getEnvironment()
 
-    List<RamlFile> getRamlFilesFromApp(String rootRamlDirectory) {
+    List<RamlFile> getRamlFilesFromApp(String rootRamlDirectory,
+                                       boolean ignoreExchange) {
         return FileSystems.newFileSystem(file.toPath(),
                                          null).withCloseable { fs ->
             def apiPath = fs.getPath(rootRamlDirectory)
@@ -82,7 +88,8 @@ abstract class FileBasedAppDeploymentRequest {
             Files.walk(apiPath).findAll { p ->
                 def relativeToApiDirectory = apiPath.relativize(p)
                 !Files.isDirectory(p) &&
-                        !isIgnored(relativeToApiDirectory)
+                        !isIgnored(relativeToApiDirectory,
+                                   ignoreExchange)
             }.collect { p ->
                 def relativeToApiDirectory = apiPath.relativize(p)
                 new RamlFile(relativeToApiDirectory.toString(),

--- a/library/src/main/java/com/avioconsulting/mule/deployment/dsl/ApiSpecContext.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/dsl/ApiSpecContext.groovy
@@ -15,7 +15,9 @@ class ApiSpecContext extends BaseContext {
         // This might sort of be a circular/weird dependency between ApiSpecification and FileBasedAppDeploymentRequest
         // but not sure of the best way to handle this
         def sourceDirectory = ApiSpecification.getSourceDirectoryOrDefault(this.sourceDirectory)
-        def ramlFiles = request.getRamlFilesFromApp(sourceDirectory)
+        // we cannot parse the RAML without included Exchange modules
+        def ramlFiles = request.getRamlFilesFromApp(sourceDirectory,
+                                                    false)
         new ApiSpecification(this.name,
                              ramlFiles,
                              this.mainRamlFile,

--- a/library/src/main/java/com/avioconsulting/mule/deployment/internal/subdeployers/DesignCenterDeployer.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/internal/subdeployers/DesignCenterDeployer.groovy
@@ -181,7 +181,10 @@ class DesignCenterDeployer implements DesignCenterHttpFunctionality, IDesignCent
 
     def synchronizeDesignCenterFromApp(ApiSpecification apiSpec,
                                        FileBasedAppDeploymentRequest appFileInfo) {
-        def ramlFilesFromApp = appFileInfo.getRamlFilesFromApp(apiSpec.sourceDirectory)
+        // For now this library ignores Exchange modules/does not try and maintain or sync them
+        // both the app and the remote/DC comparison should therefore exclude them
+        def ramlFilesFromApp = appFileInfo.getRamlFilesFromApp(apiSpec.sourceDirectory,
+                                                               true)
         synchronizeDesignCenter(apiSpec,
                                 ramlFilesFromApp,
                                 appFileInfo.appVersion)

--- a/library/src/test/java/com/avioconsulting/mule/deployment/api/models/FileBasedAppDeploymentRequestTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/api/models/FileBasedAppDeploymentRequestTest.groovy
@@ -26,7 +26,8 @@ class FileBasedAppDeploymentRequestTest implements AppBuilding {
                                tempAppDirectory)
 
         // act
-        def result = request.getRamlFilesFromApp('/api')
+        def result = request.getRamlFilesFromApp('/api',
+                                                 true)
 
         // assert
         assertThat result,
@@ -39,7 +40,8 @@ class FileBasedAppDeploymentRequestTest implements AppBuilding {
         def request = buildFullApp()
 
         // act
-        def result = request.getRamlFilesFromApp('/api')
+        def result = request.getRamlFilesFromApp('/api',
+                                                 true)
                 .sort { item -> item.fileName } // consistent for test
 
         // assert
@@ -63,7 +65,8 @@ class FileBasedAppDeploymentRequestTest implements AppBuilding {
         def request = buildFullApp()
 
         // act
-        def result = request.getRamlFilesFromApp('/api/folder')
+        def result = request.getRamlFilesFromApp('/api/folder',
+                                                 true)
                 .sort { item -> item.fileName } // consistent for test
 
         // assert
@@ -71,6 +74,35 @@ class FileBasedAppDeploymentRequestTest implements AppBuilding {
                    is(equalTo([
                            new RamlFile('lib.yaml',
                                         'howdy1')
+                   ]))
+    }
+
+    @Test
+    void getRamlFilesFromApp_include_exchange() {
+        // arrange
+        def request = buildFullApp()
+
+        // act
+        def result = request.getRamlFilesFromApp('/api',
+                                                 false)
+                .sort { item -> item.fileName } // consistent for test
+
+        // assert
+        def expectedStuffContents = [
+                '#%RAML 1.0',
+                'title: stuff',
+                'version: v1'
+        ].join('\n')
+        assertThat result,
+                   is(equalTo([
+                           new RamlFile('exchange_modules/junk',
+                                        ''),
+                           new RamlFile('exchange_modules/subdir/junk',
+                                        ''),
+                           new RamlFile('folder/lib.yaml',
+                                        'howdy1'),
+                           new RamlFile('stuff.raml',
+                                        expectedStuffContents)
                    ]))
     }
 }

--- a/library/src/test/java/com/avioconsulting/mule/deployment/internal/subdeployers/DesignCenterDeployerTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/internal/subdeployers/DesignCenterDeployerTest.groovy
@@ -1104,7 +1104,8 @@ class DesignCenterDeployerTest extends BaseTest implements AppBuilding {
         }
         def request = buildFullApp()
         def apiSpec = new ApiSpecification('Hello API',
-                                           request.getRamlFilesFromApp('/api'))
+                                           request.getRamlFilesFromApp('/api',
+                                                                       false))
 
         // act
         deployer.synchronizeDesignCenterFromApp(apiSpec,
@@ -1168,7 +1169,8 @@ class DesignCenterDeployerTest extends BaseTest implements AppBuilding {
         }
         def appInfo = buildFullApp()
         def apiSpec = new ApiSpecification('Hello API',
-                                           appInfo.getRamlFilesFromApp('/api'))
+                                           appInfo.getRamlFilesFromApp('/api',
+                                                                       false))
 
         // act
         deployer.synchronizeDesignCenterFromApp(apiSpec,

--- a/library/src/test/java/com/avioconsulting/mule/integrationtest/IntegrationTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/integrationtest/IntegrationTest.groovy
@@ -4,11 +4,7 @@ import com.avioconsulting.mule.MavenInvoke
 import com.avioconsulting.mule.deployment.TestConsoleLogger
 import com.avioconsulting.mule.deployment.api.Deployer
 import com.avioconsulting.mule.deployment.api.DryRunMode
-import com.avioconsulting.mule.deployment.api.models.ApiSpecification
-import com.avioconsulting.mule.deployment.api.models.ApiSpecificationList
-import com.avioconsulting.mule.deployment.api.models.CloudhubDeploymentRequest
-import com.avioconsulting.mule.deployment.api.models.CloudhubWorkerSpecRequest
-import com.avioconsulting.mule.deployment.api.models.OnPremDeploymentRequest
+import com.avioconsulting.mule.deployment.api.models.*
 import com.avioconsulting.mule.deployment.api.models.policies.MulesoftPolicy
 import com.avioconsulting.mule.deployment.internal.http.EnvironmentLocator
 import com.avioconsulting.mule.deployment.internal.http.HttpClientWrapper
@@ -23,11 +19,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.core.config.Configurator
-import org.junit.Assume
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Ignore
-import org.junit.Test
+import org.junit.*
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.equalTo
@@ -170,7 +162,8 @@ class IntegrationTest implements MavenInvoke {
     void cloudhub() {
         // arrange
         def apiSpec1 = new ApiSpecification('Mule Deploy Design Center Test Project',
-                                           cloudhubDeploymentRequest.getRamlFilesFromApp('/api'),
+                                           cloudhubDeploymentRequest.getRamlFilesFromApp('/api',
+                                                                                         true),
                                             'mule-deploy-design-center-test-project-v2.raml',
                                             null,
                                             null,
@@ -179,7 +172,8 @@ class IntegrationTest implements MavenInvoke {
                                             '/api')
 
         def apiSpec2 = new ApiSpecification('Mule Deploy Design Center Test Project',
-                                            cloudhubDeploymentRequest.getRamlFilesFromApp('/api_v1'),
+                                            cloudhubDeploymentRequest.getRamlFilesFromApp('/api_v1',
+                                                                                          true),
                                             'mule-deploy-design-center-test-project.raml',
                                             null,
                                             null,
@@ -268,7 +262,7 @@ class IntegrationTest implements MavenInvoke {
             println 'Existing app does not exist, no problem'
         }
         def apiSpec = new ApiSpecification('Mule Deploy Design Center Test Project',
-                                           onPremDeploymentRequest.getRamlFilesFromApp('/api'))
+                                           onPremDeploymentRequest.getRamlFilesFromApp('/api', true))
 
         // act
         overallDeployer.deployApplication(onPremDeploymentRequest,


### PR DESCRIPTION
Parsing the RAML to find the major API version requires all included RAML files, including Exchange modules, which for Design Center purposes we Exclude since we don't maintain those dependencies. This was causing an inability to parse RAMLs for apps with exchange module includes.