### PR TITLE
Soap fix

### DIFF
--- a/library/examples/soap_endpoint.groovy
+++ b/library/examples/soap_endpoint.groovy
@@ -1,0 +1,40 @@
+def muleVersionsForEnvironments = [
+        DEV: '4.2.2',
+        QA: '4.1.4'
+]
+
+muleDeploy {
+    // version of the tool
+    version '1.0'
+
+    apiSpecification {
+        name 'Mule Deploy Design Center Test Project'
+        // This will automatically disable Design Denter sync since Design Center is for REST APIs
+        // Deploy process will assume you have manually created a WSDL based Exchange asset
+        // Same logic as REST part of this deployment process will be used to derive the Exchange
+        // asset ID. for this example, it would be mule-deploy-design-center-test-project
+        soapEndpointWithVersion 'v1'
+    }
+
+    policies {
+        clientEnforcementPolicyBasic {
+            // version is optional (will use version in this library by default)
+            version '1.2.1'
+            // can supply paths just like above if necessary
+        }
+    }
+
+    cloudHubApplication {
+        environment params.environment
+        applicationName 'the-app'
+        appVersion '1.2.3'
+        // mule version for workerSpecs will be derived from POM
+        file 'something.jar'
+        cryptoKey params.cryptoKey
+        autoDiscovery {
+            clientId params.autoDiscClientId
+            clientSecret params.autoDiscClientSecret
+        }
+        cloudHubAppPrefix 'AVI'
+    }
+}

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/models/ApiSpecification.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/models/ApiSpecification.groovy
@@ -25,9 +25,14 @@ class ApiSpecification {
     final String mainRamlFile
 
     /**
-     * e.g. v1 or v2. this is optional, will be assumed to be v1 by default
+     * e.g. v1 or v2. this is optional, will be assumed to be v1 by default and it's
+     * derived from your RAML (opinionated deployment code) UNLESS you're using SOAP
+     * in which case you can manually provide it via the soapMajorApiVersion
+     * constructor parameter
      */
     final String apiMajorVersion
+
+    final boolean soapApi
 
     /**
      * The endpoint to show in the API Manager definition.
@@ -52,7 +57,8 @@ class ApiSpecification {
     final String sourceDirectory
 
     /***
-     * Standard request - see properties for parameter details
+     * Standard request - see properties for parameter details. If you have a SOAP
+     * endpoint, see the other constructor
      */
     ApiSpecification(String name,
                      List<RamlFile> ramlFiles,
@@ -75,6 +81,30 @@ class ApiSpecification {
         this.endpoint = endpoint
         this.designCenterBranchName = designCenterBranchName ?: 'master'
         this.sourceDirectory = sourceDirectory
+    }
+
+    /**
+     * Use for SOAP endpoints
+     * @param name
+     * @param soapMajorApiVersion
+     * @param exchangeAssetId
+     * @param endpoint
+     * @param autoDiscoveryPropertyName
+     */
+    ApiSpecification(String name,
+                     String soapMajorApiVersion,
+                     String exchangeAssetId = null,
+                     String endpoint = null,
+                     String autoDiscoveryPropertyName = null) {
+        this(name,
+             [],
+             null,
+             exchangeAssetId,
+             endpoint,
+             autoDiscoveryPropertyName)
+        this.apiMajorVersion = soapMajorApiVersion
+        this.soapApi = true
+        this.designCenterBranchName = null
     }
 
     static String getSourceDirectoryOrDefault(String sourceDirectory) {

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/models/FileBasedAppDeploymentRequest.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/models/FileBasedAppDeploymentRequest.groovy
@@ -85,6 +85,8 @@ abstract class FileBasedAppDeploymentRequest {
             if (!Files.exists(apiPath)) {
                 return []
             }
+            // we intentionally get everything, NOT just .raml files, in case the RAML references
+            // JSON examples, etc.
             Files.walk(apiPath).findAll { p ->
                 def relativeToApiDirectory = apiPath.relativize(p)
                 !Files.isDirectory(p) &&

--- a/library/src/main/java/com/avioconsulting/mule/deployment/dsl/ApiSpecContext.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/dsl/ApiSpecContext.groovy
@@ -4,7 +4,7 @@ import com.avioconsulting.mule.deployment.api.models.ApiSpecification
 import com.avioconsulting.mule.deployment.api.models.FileBasedAppDeploymentRequest
 
 class ApiSpecContext extends BaseContext {
-    String name, exchangeAssetId, mainRamlFile, endpoint, autoDiscoveryPropertyName, designCenterBranchName, sourceDirectory
+    String name, exchangeAssetId, mainRamlFile, endpoint, autoDiscoveryPropertyName, designCenterBranchName, sourceDirectory, soapEndpointWithVersion
 
     ApiSpecification createRequest(FileBasedAppDeploymentRequest request) {
         def errors = findErrors()
@@ -12,6 +12,24 @@ class ApiSpecContext extends BaseContext {
             def errorList = errors.join('\n')
             throw new Exception("Your API spec is not complete. The following errors exist:\n${errorList}")
         }
+        if (this.soapEndpointWithVersion) {
+            if (this.mainRamlFile || this.designCenterBranchName || this.sourceDirectory) {
+                throw new Exception('You used soapEndpointWithVersion but also supplied 1 or more of the following. These are not compatible! mainRamlFile, designCenterBranchName, sourceDirectory')
+            }
+            return createSoapSpec()
+        }
+        return createRestSpec(request)
+    }
+
+    private ApiSpecification createSoapSpec() {
+        return new ApiSpecification(this.name,
+                                    this.soapEndpointWithVersion,
+                                    this.exchangeAssetId,
+                                    this.endpoint,
+                                    this.autoDiscoveryPropertyName)
+    }
+
+    private ApiSpecification createRestSpec(FileBasedAppDeploymentRequest request) {
         // This might sort of be a circular/weird dependency between ApiSpecification and FileBasedAppDeploymentRequest
         // but not sure of the best way to handle this
         def sourceDirectory = ApiSpecification.getSourceDirectoryOrDefault(this.sourceDirectory)
@@ -30,6 +48,12 @@ class ApiSpecContext extends BaseContext {
 
     @Override
     List<String> findOptionalProperties() {
-        ['exchangeAssetId', 'mainRamlFile', 'endpoint', 'autoDiscoveryPropertyName', 'designCenterBranchName', 'sourceDirectory']
+        ['exchangeAssetId',
+         'mainRamlFile',
+         'endpoint',
+         'autoDiscoveryPropertyName',
+         'designCenterBranchName',
+         'sourceDirectory',
+         'soapEndpointWithVersion']
     }
 }

--- a/library/src/main/resources/evaluate.gdsl.vm
+++ b/library/src/main/resources/evaluate.gdsl.vm
@@ -116,6 +116,7 @@ contributor([closureScopeContext]) {
         #stringParam('autoDiscoveryPropertyName')
         #stringParam('designCenterBranchName')
         #stringParam('sourceDirectory')
+        #stringParam('soapEndpointWithVersion')
     }
     call = enclosingCall('policies')
     if (call) {

--- a/library/src/test/java/com/avioconsulting/mule/deployment/DeployerTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/DeployerTest.groovy
@@ -484,6 +484,41 @@ class DeployerTest {
     }
 
     @Test
+    void deployApplication_soap() {
+        // arrange
+        def file = new File('src/test/resources/some_file.txt')
+        def request = new CloudhubDeploymentRequest('DEV',
+                                                    new CloudhubWorkerSpecRequest('3.9.1',
+                                                                                  false,
+                                                                                  1,
+                                                                                  WorkerTypes.Micro,
+                                                                                  AwsRegions.UsEast1),
+                                                    file,
+                                                    'theKey',
+                                                    'theClientId',
+                                                    'theSecret',
+                                                    'client',
+                                                    'new-app',
+                                                    '1.2.3')
+        def apiSpec = new ApiSpecification('Hello SOAP API',
+                                           'v1')
+
+        // act
+        deployer.deployApplication(request,
+                                   new ApiSpecificationList([apiSpec]))
+
+        // assert
+        assertThat deployedChApps.size(),
+                   is(equalTo(1))
+        assertThat 'API sync should still happen',
+                   apiSyncs.size(),
+                   is(equalTo(1))
+        assertThat 'If a SOAP API is in use, we should not sync to DC',
+                   designCenterSyncs.size(),
+                   is(equalTo(0))
+    }
+
+    @Test
     void multiple_api_specs() {
         // arrange
         def file = new File('src/test/resources/some_file.txt')

--- a/library/src/test/java/com/avioconsulting/mule/deployment/api/models/ApiSpecificationTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/api/models/ApiSpecificationTest.groovy
@@ -39,6 +39,8 @@ class ApiSpecificationTest {
                    is(equalTo('master'))
         assertThat result.sourceDirectory,
                    is(equalTo('/api'))
+        assertThat result.soapApi,
+                   is(equalTo(false))
     }
 
     @Test
@@ -278,12 +280,7 @@ class ApiSpecificationTest {
 
         // act
         def result = new ApiSpecification('SystemStuff SOAP API',
-                                          [
-                                                  // SOAP projects will have WSDLs in here
-                                                  new RamlFile('stuff-v1.wsdl',
-                                                               ['<xml/>'].join('\n'))
-                                          ],
-                                          null,
+                                          'v1',
                                           'nope')
 
         // assert
@@ -293,5 +290,9 @@ class ApiSpecificationTest {
                    is(equalTo('nope'))
         assertThat result.mainRamlFile,
                    is(nullValue())
+        assertThat result.soapApi,
+                   is(equalTo(true))
+        assertThat result.apiMajorVersion,
+                   is(equalTo('v1'))
     }
 }

--- a/library/src/test/java/com/avioconsulting/mule/deployment/api/models/ApiSpecificationTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/api/models/ApiSpecificationTest.groovy
@@ -278,7 +278,11 @@ class ApiSpecificationTest {
 
         // act
         def result = new ApiSpecification('SystemStuff SOAP API',
-                                          [],
+                                          [
+                                                  // SOAP projects will have WSDLs in here
+                                                  new RamlFile('stuff-v1.wsdl',
+                                                               ['<xml/>'].join('\n'))
+                                          ],
                                           null,
                                           'nope')
 

--- a/library/src/test/java/com/avioconsulting/mule/deployment/dsl/ApiSpecContextTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/dsl/ApiSpecContextTest.groovy
@@ -40,6 +40,63 @@ class ApiSpecContextTest implements AppBuilding {
     }
 
     @Test
+    void soap() {
+        // arrange
+        def appRequest = buildFullApp()
+        def context = new ApiSpecContext()
+        def closure = {
+            name 'Foo Bar'
+            soapEndpointWithVersion 'v1'
+        }
+        closure.delegate = context
+        closure.call()
+
+        // act
+        def request = context.createRequest(appRequest)
+
+        // assert
+        request.with {
+            assertThat it.name,
+                       is(equalTo('Foo Bar'))
+            assertThat it.mainRamlFile,
+                       is(nullValue())
+            assertThat it.exchangeAssetId,
+                       is(equalTo('foo-bar'))
+            assertThat it.endpoint,
+                       is(nullValue())
+            assertThat it.autoDiscoveryPropertyName,
+                       is(equalTo('auto-discovery.api-id'))
+            assertThat it.designCenterBranchName,
+                       is(nullValue())
+            assertThat it.soapApi,
+                       is(equalTo(true))
+        }
+    }
+
+    @Test
+    void soap_and_rest() {
+        // arrange
+        def appRequest = buildFullApp()
+        def context = new ApiSpecContext()
+        def closure = {
+            name 'Foo Bar'
+            soapEndpointWithVersion 'v1'
+            designCenterBranchName ' stuff'
+        }
+        closure.delegate = context
+        closure.call()
+
+        // act
+        def exception = shouldFail {
+            context.createRequest(appRequest)
+        }
+
+        // assert
+        assertThat exception.message,
+                   is(containsString('You used soapEndpointWithVersion but also supplied 1 or more of the following. These are not compatible! mainRamlFile, designCenterBranchName, sourceDirectory'))
+    }
+
+    @Test
     void includes_optional() {
         // arrange
         def appRequest = buildFullApp()


### PR DESCRIPTION
Status quo would pick up WSDLs in `src/main/resources/api` and try and parse them as RAMLs. And value defaulting preventing disabling that behavior by setting `mainRamlFile` to null.

This way should be more explicit.