### PR TITLE
Adding connectedApp authentication to HTTP Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ schema.json
 evaluate.gdsl
 maven-plugin/stuff.groovy
 cli/stuff.groovy
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Both approaches 1 and 2 lean on using a Groovy DSL to supply your deployment spe
 
 ALL of these methods assume your CI/CD tool white lists secrets from output. If it does not, it's on YOU to deal with that. Jenkins and Azure DevOps should do this out of the box with no further configuration.
 
+# Authentication
+The tool supports two type of authentication methods -
+1. Basic Anypoint Platform Credentials
+2. Anypoint [Connected App Credentials](https://help.mulesoft.com/s/article/How-to-deploy-an-application-to-CloudHub-using-Connected-App-functionality)
+
 # Maven plugin
 
 NOTE: The Maven plugin has 2 goals (deploy and validate). Regardless of whether you use it to actually perform the deployment, it's highly recommended you use the validate goal to ensure your DSL file is correct during the build pipeline.
@@ -66,7 +71,12 @@ If you have no strong preference, then stick with the "with POM" approach which 
 mvn clean deploy -DmuleDeploy.env=DEV -Danypoint.username=bob -Danypoint.password=asecret -DmuleDeploy.cryptoKey=hello -DmuleDeploy.autoDiscClientId=theId -DmuleDeploy.autoDiscClientSecret=theSecret
 ```
 
-See maven-plugin/README.md for more information.
+To see all parameters, run help goal of the plugin:
+```shell
+mvn com.avioconsulting.mule:mule-deploy-maven-plugin:help -Ddetail=true
+```
+
+See [maven-plugin/README.md](./maven-plugin/README.md) for more information.
 
 # CLI
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -38,9 +38,10 @@ You can get an idea of available options by running `./muleDeploy --help`:
 
 ```
 Missing required parameter: <groovyFile>
-Usage: deploy [-V] [-m=<dryRunMode>] [-o=<anypointOrganizationName>]
-              -p=<anypointPassword> -u=<anypointUsername>
-              [-a=<String=String>]...
+Usage: deploy ([-u=<anypointUsername> -p=<anypointPassword>]
+              [-caid=<anypointConnectedAppId>
+              -casec=<anypointConnectedAppSecret>]) [-V] [-m=<dryRunMode>]
+              [-o=<anypointOrganizationName>] [-a=<String=String>]...
               [-e=<environmentsToDoDesignCenterDeploymentOn>]... <groovyFile>
 Will deploy using your Mule DSL
       <groovyFile>   The path to your DSL file
@@ -57,11 +58,16 @@ Will deploy using your Mule DSL
   -o, --anypoint-org-name=<anypointOrganizationName>
                      The org/business group to use. If you do not specify it,
                        the default for your user will be used
+  -V, --version      print version info
+Basic auth credentials of Anypoint Platform
   -p, --anypoint-password=<anypointPassword>
 
   -u, --anypoint-username=<anypointUsername>
 
-  -V, --version      print version info
+Connected App credentials
+      -caid, --anypoint-connected-app-id=<anypointConnectedAppId>
+
+      -casec, --anypoint-connected-app-secret=<anypointConnectedAppSecret>
 
 ```
 

--- a/cli/src/main/java/com/avioconsulting/mule/cli/DeployerCommandLine.groovy
+++ b/cli/src/main/java/com/avioconsulting/mule/cli/DeployerCommandLine.groovy
@@ -21,10 +21,14 @@ import java.util.concurrent.Callable
 class DeployerCommandLine implements Callable<Integer> {
     @Parameters(index = '0', description = 'The path to your DSL file')
     private File groovyFile
-    @Option(names = ['-u', '--anypoint-username'], required = true)
+    @Option(names = ['-u', '--anypoint-username'])
     private String anypointUsername
-    @Option(names = ['-p', '--anypoint-password'], required = true)
+    @Option(names = ['-p', '--anypoint-password'])
     private String anypointPassword
+    @Option(names = ['-i', '--anypoint-connected-app-id'])
+    private String anypointConnectedAppId
+    @Option(names = ['-s', '--anypoint-connected-app-secret'])
+    private String anypointConnectedAppSecret
     @Option(names = ['-o', '--anypoint-org-name'],
             description = 'The org/business group to use. If you do not specify it, the default for your user will be used')
     private String anypointOrganizationName
@@ -62,10 +66,15 @@ class DeployerCommandLine implements Callable<Integer> {
         logger.println "Successfully processed ${groovyFile} through DSL"
         def deployer = deployerFactory.create(this.anypointUsername,
                                               this.anypointPassword,
+                                              this.anypointConnectedAppId,
+                                              this.anypointConnectedAppSecret,
                                               logger,
                                               this.dryRunMode,
                                               this.anypointOrganizationName,
                                               this.environmentsToDoDesignCenterDeploymentOn)
+        if (this.anypointUsername == null && this.anypointPassword == null && this.anypointConnectedAppId == null && this.anypointConnectedAppSecret == null) {
+            throw new Exception("Either --anypoint-username and --anypoint-password or --anypoint-connected-app-id and --anypoint-connected-app-secret must be defined.")
+        }
         if (this.dryRunMode == DryRunMode.OfflineValidate) {
             logger.println 'Offline validate was specified, so not deploying'
             return

--- a/cli/src/test/java/com/avioconsulting/mule/cli/DeployerCommandLineTest.groovy
+++ b/cli/src/test/java/com/avioconsulting/mule/cli/DeployerCommandLineTest.groovy
@@ -5,6 +5,7 @@ import com.avioconsulting.mule.deployment.api.IDeployer
 import com.avioconsulting.mule.deployment.api.IDeployerFactory
 import com.avioconsulting.mule.deployment.api.ILogger
 import com.avioconsulting.mule.deployment.api.models.*
+import com.avioconsulting.mule.deployment.api.models.credentials.Credential
 import com.avioconsulting.mule.deployment.api.models.policies.Policy
 import org.apache.commons.io.FileUtils
 import org.junit.BeforeClass
@@ -40,9 +41,9 @@ class DeployerCommandLineTest implements MavenInvoke {
         def args
         if (connId != null && connSecret != null)
             args = [
-                    '-i',
+                    '-caid',
                     "\"${connId}\"".toString(),
-                    '-s',
+                    '-casec',
                     "\"${connSecret}\"".toString(),
                     '-m',
                     dryRunMode.name()
@@ -91,8 +92,7 @@ class DeployerCommandLineTest implements MavenInvoke {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -150,8 +150,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String connectedAppId,
-                          String connectedAppSecret,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -205,8 +204,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -254,8 +252,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -319,8 +316,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -350,8 +346,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/Deployer.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/Deployer.groovy
@@ -40,6 +40,8 @@ class Deployer implements IDeployer {
      */
     Deployer(String username,
              String password,
+             String connectedAppId,
+             String connectedAppSecret,
              ILogger logger,
              DryRunMode dryRunMode,
              String anypointOrganizationName = null,
@@ -48,6 +50,8 @@ class Deployer implements IDeployer {
         this(new HttpClientWrapper(baseUrl,
                                    username,
                                    password,
+                                   connectedAppId,
+                                   connectedAppSecret,
                                    logger,
                                    anypointOrganizationName),
              dryRunMode,

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/Deployer.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/Deployer.groovy
@@ -5,6 +5,7 @@ import com.avioconsulting.mule.deployment.api.models.ApiSpecificationList
 import com.avioconsulting.mule.deployment.api.models.CloudhubDeploymentRequest
 import com.avioconsulting.mule.deployment.api.models.Features
 import com.avioconsulting.mule.deployment.api.models.FileBasedAppDeploymentRequest
+import com.avioconsulting.mule.deployment.api.models.credentials.Credential
 import com.avioconsulting.mule.deployment.api.models.policies.Policy
 import com.avioconsulting.mule.deployment.internal.http.EnvironmentLocator
 import com.avioconsulting.mule.deployment.internal.http.HttpClientWrapper
@@ -30,28 +31,21 @@ class Deployer implements IDeployer {
 
     /**
      *
-     * @param username anypoint creds to deploy with
-     * @param password anypoint creds to deploy with
+     * @param credential {@link Credential } to access anypoint platform.
      * @param logger all messages will be logged like this. This is Jenkins plugins friendly (or you can supply System.out)
      * @param dryRunMode Should we do a real run?
      * @param anypointOrganizationName Optional parameter. If null, the default organization/biz group for the user will be used. Otherwise supply name (NOT GUID) of the biz group or organization you want to use
      * @param baseUrl Base URL, optional
      * @param environmentsToDoDesignCenterDeploymentOn Normally workflow wise you'd only want to do this on DEV
      */
-    Deployer(String username,
-             String password,
-             String connectedAppId,
-             String connectedAppSecret,
+    Deployer(Credential credential,
              ILogger logger,
              DryRunMode dryRunMode,
              String anypointOrganizationName = null,
              String baseUrl = 'https://anypoint.mulesoft.com',
              List<String> environmentsToDoDesignCenterDeploymentOn = ['DEV']) {
         this(new HttpClientWrapper(baseUrl,
-                                   username,
-                                   password,
-                                   connectedAppId,
-                                   connectedAppSecret,
+                                   credential,
                                    logger,
                                    anypointOrganizationName),
              dryRunMode,

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/DeployerFactory.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/DeployerFactory.groovy
@@ -1,19 +1,15 @@
 package com.avioconsulting.mule.deployment.api
 
+import com.avioconsulting.mule.deployment.api.models.credentials.Credential
+
 class DeployerFactory implements IDeployerFactory {
     @Override
-    IDeployer create(String username,
-                     String password,
-                     String connectedAppId,
-                     String connectedAppSecret,
+    IDeployer create(Credential credential,
                      ILogger logger,
                      DryRunMode dryRunMode,
                      String anypointOrganizationName,
                      List<String> environmentsToDoDesignCenterDeploymentOn) {
-        new Deployer(username,
-                     password,
-                     connectedAppId,
-                     connectedAppSecret,
+        new Deployer(credential,
                      logger,
                      dryRunMode,
                      anypointOrganizationName,

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/DeployerFactory.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/DeployerFactory.groovy
@@ -4,12 +4,16 @@ class DeployerFactory implements IDeployerFactory {
     @Override
     IDeployer create(String username,
                      String password,
+                     String connectedAppId,
+                     String connectedAppSecret,
                      ILogger logger,
                      DryRunMode dryRunMode,
                      String anypointOrganizationName,
                      List<String> environmentsToDoDesignCenterDeploymentOn) {
         new Deployer(username,
                      password,
+                     connectedAppId,
+                     connectedAppSecret,
                      logger,
                      dryRunMode,
                      anypointOrganizationName,

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/IDeployerFactory.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/IDeployerFactory.groovy
@@ -3,6 +3,8 @@ package com.avioconsulting.mule.deployment.api
 interface IDeployerFactory {
     IDeployer create(String username,
                      String password,
+                     String connectedAppId,
+                     String connectedAppSecret,
                      ILogger logger,
                      DryRunMode dryRunMode,
                      String anypointOrganizationName,

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/IDeployerFactory.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/IDeployerFactory.groovy
@@ -1,10 +1,9 @@
 package com.avioconsulting.mule.deployment.api
 
+import com.avioconsulting.mule.deployment.api.models.credentials.Credential
+
 interface IDeployerFactory {
-    IDeployer create(String username,
-                     String password,
-                     String connectedAppId,
-                     String connectedAppSecret,
+    IDeployer create(Credential credential,
                      ILogger logger,
                      DryRunMode dryRunMode,
                      String anypointOrganizationName,

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/models/credentials/ConnectedAppCredential.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/models/credentials/ConnectedAppCredential.groovy
@@ -1,0 +1,25 @@
+package com.avioconsulting.mule.deployment.api.models.credentials
+
+import groovy.transform.Immutable
+
+/**
+ * Connected App credentials for accessing Anypoint Platform.
+ */
+@Immutable
+class ConnectedAppCredential extends Credential {
+
+    /**
+     * Connected App Id
+     */
+    final String id;
+
+    /**
+     * Connected App Secret
+     */
+    final String secret;
+
+    @Override
+    String getPrincipal() {
+        return id
+    }
+}

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/models/credentials/Credential.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/models/credentials/Credential.groovy
@@ -1,0 +1,9 @@
+package com.avioconsulting.mule.deployment.api.models.credentials;
+
+/**
+ * Abstract Base class for defining anypoint platform access credentials
+ */
+abstract class Credential {
+
+    abstract String getPrincipal()
+}

--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/models/credentials/UsernamePasswordCredential.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/models/credentials/UsernamePasswordCredential.groovy
@@ -1,0 +1,26 @@
+package com.avioconsulting.mule.deployment.api.models.credentials
+
+import groovy.transform.Immutable;
+
+
+/**
+ * Basic username and password credentials for accessing Anypoint Platform.
+ */
+@Immutable
+class UsernamePasswordCredential extends Credential {
+
+    /**
+     * Anypoint Username
+     */
+    final String username;
+
+    /**
+     * Anypoint Password
+     */
+    final String password;
+
+    @Override
+    String getPrincipal() {
+        return username
+    }
+}

--- a/library/src/main/java/com/avioconsulting/mule/deployment/internal/http/HttpClientWrapper.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/internal/http/HttpClientWrapper.groovy
@@ -1,6 +1,9 @@
 package com.avioconsulting.mule.deployment.internal.http
 
 import com.avioconsulting.mule.deployment.api.ILogger
+import com.avioconsulting.mule.deployment.api.models.credentials.ConnectedAppCredential
+import com.avioconsulting.mule.deployment.api.models.credentials.Credential
+import com.avioconsulting.mule.deployment.api.models.credentials.UsernamePasswordCredential
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import org.apache.http.HttpException
@@ -16,10 +19,6 @@ import org.apache.http.impl.client.HttpClients
 import org.apache.http.protocol.HttpContext
 
 class HttpClientWrapper implements HttpRequestInterceptor {
-    private final String username
-    private final String password
-    private final String connectedAppId
-    private final String connectedAppSecret
     private String accessToken
     private String ownerGuid
     private final ILogger logger
@@ -27,19 +26,14 @@ class HttpClientWrapper implements HttpRequestInterceptor {
     private final CloseableHttpClient httpClient
     private final String anypointOrganizationName
     private String anypointOrganizationId
+    private Credential credential
 
     HttpClientWrapper(String baseUrl,
-                      String username,
-                      String password,
-                      String connectedAppId = null,
-                      String connectedAppSecret = null,
+                      Credential credential,
                       ILogger logger,
                       String anypointOrganizationName = null) {
+        this.credential = credential
         this.anypointOrganizationName = anypointOrganizationName
-        this.password = password
-        this.username = username
-        this.connectedAppId = connectedAppId
-        this.connectedAppSecret = connectedAppSecret
         this.logger = logger
         this.baseUrl = baseUrl
         this.httpClient = HttpClients.custom()
@@ -56,10 +50,7 @@ class HttpClientWrapper implements HttpRequestInterceptor {
 
     private def authenticate() {
         if (!this.accessToken) {
-            if (username != null)
-                fetchAccessTokenAsUser()
-            else if (connectedAppId != null)
-                fetchAccessTokenWithConnectedApp()
+            fetchAccessToken(this.credential)
             fetchUserInfo()
         }
     }
@@ -84,7 +75,7 @@ class HttpClientWrapper implements HttpRequestInterceptor {
                     org.id == this.anypointOrganizationId
                 }?.name
                 if (name) {
-                    logger.println("Using default organization for ${username} of '${name}'")
+                    logger.println("Using default organization for ${this.credential.getPrincipal()} of '${name}'")
                 } else {
                     throw new Exception('No Anypoint org was specified and was unable to find a default one! This should not happen!')
                 }
@@ -100,11 +91,11 @@ class HttpClientWrapper implements HttpRequestInterceptor {
         }
     }
 
-    private def fetchAccessTokenAsUser() {
-        logger.println "Authenticating to Anypoint as user '${username}'"
+    private def fetchAccessToken(UsernamePasswordCredential cred) {
+        logger.println "Authenticating to Anypoint as user '${cred.username}'"
         def payload = [
-                username: username,
-                password: password
+                username: cred.username,
+                password: cred.password
         ]
         def request = new HttpPost("${baseUrl}/accounts/login").with {
             setEntity(new StringEntity(JsonOutput.toJson(payload)))
@@ -114,17 +105,17 @@ class HttpClientWrapper implements HttpRequestInterceptor {
         }
         httpClient.execute(request).with { response ->
             def result = assertSuccessfulResponseAndReturnJson(response,
-                                                               "authenticate to Anypoint as '${username}'")
+                                                               "authenticate to Anypoint as '${cred.username}'")
             logger.println 'Successfully authenticated'
             accessToken = result.access_token
         }
     }
 
-    private def fetchAccessTokenWithConnectedApp() {
-        logger.println "Authenticating to Anypoint with connected app '${connectedAppId}'"
+    private def fetchAccessToken(ConnectedAppCredential cred) {
+        logger.println "Authenticating to Anypoint with connected app '${cred.id}'"
         def payload = [
-                client_id: connectedAppId,
-                client_secret: connectedAppSecret,
+                client_id: cred.id,
+                client_secret: cred.secret,
                 grant_type: "client_credentials"
         ]
         def request = new HttpPost("${baseUrl}/accounts/api/v2/oauth2/token").with {
@@ -135,7 +126,7 @@ class HttpClientWrapper implements HttpRequestInterceptor {
         }
         httpClient.execute(request).with { response ->
             def result = assertSuccessfulResponseAndReturnJson(response,
-                    "authenticate to Anypoint with connected app '${connectedAppId}'")
+                    "authenticate to Anypoint with connected app '${cred.id}'")
             logger.println 'Successfully authenticated'
             accessToken = result.access_token
         }

--- a/library/src/test/java/com/avioconsulting/mule/deployment/BaseTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/BaseTest.groovy
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture
 class BaseTest {
     protected HttpServer httpServer
     protected HttpClientWrapper clientWrapper
+    protected HttpClientWrapper clientWrapperConnectedApp
     protected EnvironmentLocator environmentLocator
     protected Handler<HttpServerRequest> closure
 
@@ -42,8 +43,17 @@ class BaseTest {
         clientWrapper = new HttpClientWrapper("http://localhost:${httpServer.actualPort()}",
                                               'the user',
                                               'the password',
+                                              null,
+                                              null,
                                               new TestConsoleLogger(),
                                               'the-org-name')
+        clientWrapperConnectedApp = new HttpClientWrapper("http://localhost:${httpServer.actualPort()}",
+                null,
+                null,
+                'the client',
+                'the secret',
+                new TestConsoleLogger(),
+                'the-org-name')
         environmentLocator = new EnvironmentLocator(clientWrapper,
                                                     new TestConsoleLogger())
     }

--- a/library/src/test/java/com/avioconsulting/mule/deployment/BaseTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/BaseTest.groovy
@@ -1,5 +1,7 @@
 package com.avioconsulting.mule.deployment
 
+import com.avioconsulting.mule.deployment.api.models.credentials.ConnectedAppCredential
+import com.avioconsulting.mule.deployment.api.models.credentials.UsernamePasswordCredential
 import com.avioconsulting.mule.deployment.internal.http.EnvironmentLocator
 import com.avioconsulting.mule.deployment.internal.http.HttpClientWrapper
 import groovy.json.JsonOutput
@@ -41,17 +43,14 @@ class BaseTest {
         httpServer = createServer()
         closure = null
         clientWrapper = new HttpClientWrapper("http://localhost:${httpServer.actualPort()}",
-                                              'the user',
-                                              'the password',
-                                              null,
-                                              null,
+                                              new UsernamePasswordCredential('the user',
+                                              'the password'),
                                               new TestConsoleLogger(),
                                               'the-org-name')
         clientWrapperConnectedApp = new HttpClientWrapper("http://localhost:${httpServer.actualPort()}",
-                null,
-                null,
+                new ConnectedAppCredential(
                 'the client',
-                'the secret',
+                'the secret'),
                 new TestConsoleLogger(),
                 'the-org-name')
         environmentLocator = new EnvironmentLocator(clientWrapper,

--- a/library/src/test/java/com/avioconsulting/mule/deployment/internal/http/HttpClientWrapperTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/internal/http/HttpClientWrapperTest.groovy
@@ -2,6 +2,7 @@ package com.avioconsulting.mule.deployment.internal.http
 
 import com.avioconsulting.mule.deployment.BaseTest
 import com.avioconsulting.mule.deployment.TestConsoleLogger
+import com.avioconsulting.mule.deployment.api.models.credentials.UsernamePasswordCredential
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import io.vertx.core.http.HttpServerRequest
@@ -270,8 +271,8 @@ class HttpClientWrapperTest extends BaseTest {
     void getAnypointOrganizationId_default_org_prefs_exist() {
         // arrange
         clientWrapper = new HttpClientWrapper("http://localhost:${httpServer.actualPort()}",
-                                              'the user',
-                                              'the password',
+                                              new UsernamePasswordCredential('the user',
+                                              'the password'),
                                               new TestConsoleLogger())
         withHttpServer { HttpServerRequest request ->
             request.response().with {
@@ -319,8 +320,8 @@ class HttpClientWrapperTest extends BaseTest {
     void getAnypointOrganizationId_default_no_org_prefs_exist() {
         // arrange
         clientWrapper = new HttpClientWrapper("http://localhost:${httpServer.actualPort()}",
-                                              'the user',
-                                              'the password',
+                                              new UsernamePasswordCredential('the user',
+                                              'the password'),
                                               new TestConsoleLogger())
         withHttpServer { HttpServerRequest request ->
             request.response().with {

--- a/library/src/test/java/com/avioconsulting/mule/integrationtest/IntegrationTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/integrationtest/IntegrationTest.groovy
@@ -31,6 +31,8 @@ class IntegrationTest implements MavenInvoke {
     private static final String AVIO_SANDBOX_BIZ_GROUP_NAME = 'AVIO Sandbox'
     private static final String ANYPOINT_USERNAME = System.getProperty('anypoint.username')
     private static final String ANYPOINT_PASSWORD = System.getProperty('anypoint.password')
+    private static final String ANYPOINT_CONNECTED_APP_ID = System.getProperty('anypoint.connected-app-id')
+    private static final String ANYPOINT_CONNECTED_APP_SECRET = System.getProperty('anypoint.connected-app-secret')
     private static final String ANYPOINT_CLIENT_ID = System.getProperty('anypoint.client.id')
     private static final String ANYPOINT_CLIENT_SECRET = System.getProperty('anypoint.client.secret')
     private static final String ON_PREM_SERVER_NAME = System.getProperty('mule4.onprem.server.name')
@@ -53,8 +55,13 @@ class IntegrationTest implements MavenInvoke {
         // cut down on the unit test noise here
         Configurator.setLevel('org.apache.http.wire',
                               Level.INFO)
-        assert ANYPOINT_USERNAME: 'Did you forget -Danypoint.username?'
-        assert ANYPOINT_PASSWORD: 'Did you forget -Danypoint.password?'
+        if (!ANYPOINT_CLIENT_ID && !ANYPOINT_CLIENT_SECRET) {
+            assert ANYPOINT_USERNAME: 'Did you forget -Danypoint.username?'
+            assert ANYPOINT_PASSWORD: 'Did you forget -Danypoint.password?'
+        } else {
+            assert ANYPOINT_CONNECTED_APP_ID: 'Did you forget -Danypoint.connected-app-id?'
+            assert ANYPOINT_CONNECTED_APP_SECRET: 'Did you forget -Danypoint.connected-app-secret?'
+        }
         assert ANYPOINT_CLIENT_ID: 'Did you forget -Danypoint.client.id?'
         assert ANYPOINT_CLIENT_SECRET: 'Did you forget -Danypoint.client.secret?'
     }
@@ -127,6 +134,8 @@ class IntegrationTest implements MavenInvoke {
         clientWrapper = new HttpClientWrapper('https://anypoint.mulesoft.com',
                                               ANYPOINT_USERNAME,
                                               ANYPOINT_PASSWORD,
+                                              ANYPOINT_CONNECTED_APP_ID,
+                                              ANYPOINT_CONNECTED_APP_SECRET,
                                               logger,
                                               AVIO_SANDBOX_BIZ_GROUP_NAME)
         def environmentLocator = new EnvironmentLocator(this.clientWrapper,

--- a/library/src/test/java/com/avioconsulting/mule/integrationtest/IntegrationTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/integrationtest/IntegrationTest.groovy
@@ -31,8 +31,8 @@ class IntegrationTest implements MavenInvoke {
     private static final String AVIO_SANDBOX_BIZ_GROUP_NAME = 'AVIO Sandbox'
     private static final String ANYPOINT_USERNAME = System.getProperty('anypoint.username')
     private static final String ANYPOINT_PASSWORD = System.getProperty('anypoint.password')
-    private static final String ANYPOINT_CONNECTED_APP_ID = System.getProperty('anypoint.connected-app-id')
-    private static final String ANYPOINT_CONNECTED_APP_SECRET = System.getProperty('anypoint.connected-app-secret')
+    private static final String ANYPOINT_CONNECTED_APP_ID = System.getProperty('anypoint.connected-app.id')
+    private static final String ANYPOINT_CONNECTED_APP_SECRET = System.getProperty('anypoint.connected-app.secret')
     private static final String ANYPOINT_CLIENT_ID = System.getProperty('anypoint.client.id')
     private static final String ANYPOINT_CLIENT_SECRET = System.getProperty('anypoint.client.secret')
     private static final String ON_PREM_SERVER_NAME = System.getProperty('mule4.onprem.server.name')
@@ -59,8 +59,8 @@ class IntegrationTest implements MavenInvoke {
             assert ANYPOINT_USERNAME: 'Did you forget -Danypoint.username?'
             assert ANYPOINT_PASSWORD: 'Did you forget -Danypoint.password?'
         } else {
-            assert ANYPOINT_CONNECTED_APP_ID: 'Did you forget -Danypoint.connected-app-id?'
-            assert ANYPOINT_CONNECTED_APP_SECRET: 'Did you forget -Danypoint.connected-app-secret?'
+            assert ANYPOINT_CONNECTED_APP_ID: 'Did you forget -Danypoint.connected-app.id?'
+            assert ANYPOINT_CONNECTED_APP_SECRET: 'Did you forget -Danypoint.connected-app.secret?'
         }
         assert ANYPOINT_CLIENT_ID: 'Did you forget -Danypoint.client.id?'
         assert ANYPOINT_CLIENT_SECRET: 'Did you forget -Danypoint.client.secret?'

--- a/library/src/test/java/com/avioconsulting/mule/integrationtest/IntegrationTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/integrationtest/IntegrationTest.groovy
@@ -55,7 +55,7 @@ class IntegrationTest implements MavenInvoke {
         // cut down on the unit test noise here
         Configurator.setLevel('org.apache.http.wire',
                               Level.INFO)
-        if (!ANYPOINT_CLIENT_ID && !ANYPOINT_CLIENT_SECRET) {
+        if (!ANYPOINT_CONNECTED_APP_ID && !ANYPOINT_CONNECTED_APP_SECRET) {
             assert ANYPOINT_USERNAME: 'Did you forget -Danypoint.username?'
             assert ANYPOINT_PASSWORD: 'Did you forget -Danypoint.password?'
         } else {

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -36,6 +36,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <!--Enables to run help goal and print all parameter values
+                        `mvn com.avioconsulting.mule:mule-deploy-maven-plugin:{version}:help -Ddetail=true`-->
+                        <id>generated-helpmojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <!-- We don't want to scan this plugin's dependencies because 1) we're only
                      exposing our own mojos and 2) the scanner chokes on some of the JSON schema validator libs

--- a/maven-plugin/src/main/java/com/avioconsulting/mule/maven/MuleDeployMojo.groovy
+++ b/maven-plugin/src/main/java/com/avioconsulting/mule/maven/MuleDeployMojo.groovy
@@ -16,6 +16,10 @@ class MuleDeployMojo extends BaseMojo {
     private String anypointUsername
     @Parameter(property = 'anypoint.password')
     private String anypointPassword
+    @Parameter(property = 'anypoint.connected-app-id')
+    private String anypointConnectedAppId
+    @Parameter(property = 'anypoint.connected-app-secret')
+    private String anypointConnectedAppSecret
     @Parameter(property = 'anypoint.org.name')
     private String anypointOrganizationName
     @Parameter(defaultValue = 'DEV', property = 'design.center.deployments')
@@ -24,7 +28,7 @@ class MuleDeployMojo extends BaseMojo {
 
     @Override
     void execute() throws MojoExecutionException, MojoFailureException {
-        if (dryRunMode != DryRunMode.OfflineValidate && !(anypointUsername || anypointPassword)) {
+        if (dryRunMode != DryRunMode.OfflineValidate && !(anypointUsername || anypointPassword || anypointConnectedAppId || anypointConnectedAppSecret)) {
             throw new Exception("In order to ${dryRunMode}, credentials must be supplied via the anypointUsername <config> item/anypoint.username property and the anypointPassword <config> item/anypoint.password property")
         }
         def deploymentPackage = processDsl()
@@ -36,10 +40,15 @@ class MuleDeployMojo extends BaseMojo {
         logger.println 'Beginning deployment'
         def deployer = deployerFactory.create(this.anypointUsername,
                                               this.anypointPassword,
+                                              this.anypointConnectedAppId,
+                                              this.anypointConnectedAppSecret,
                                               logger,
                                               this.dryRunMode,
                                               this.anypointOrganizationName,
                                               this.environmentsToDoDesignCenterDeploymentOn)
+        if (this.anypointUsername == null && this.anypointPassword == null && this.anypointConnectedAppId == null && this.anypointConnectedAppSecret == null) {
+            throw new Exception("Either anypoint.username and anypoint.password or anypoint.connected-app-id and anypoint.connected-app-secret must be defined.")
+        }
         try {
             deployer.deployApplication(deploymentPackage.deploymentRequest,
                                        deploymentPackage.apiSpecifications,

--- a/maven-plugin/src/main/java/com/avioconsulting/mule/maven/MuleDeployMojo.groovy
+++ b/maven-plugin/src/main/java/com/avioconsulting/mule/maven/MuleDeployMojo.groovy
@@ -3,6 +3,9 @@ package com.avioconsulting.mule.maven
 import com.avioconsulting.mule.deployment.api.DeployerFactory
 import com.avioconsulting.mule.deployment.api.DryRunMode
 import com.avioconsulting.mule.deployment.api.IDeployerFactory
+import com.avioconsulting.mule.deployment.api.models.credentials.ConnectedAppCredential
+import com.avioconsulting.mule.deployment.api.models.credentials.Credential
+import com.avioconsulting.mule.deployment.api.models.credentials.UsernamePasswordCredential
 import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.plugin.MojoFailureException
 import org.apache.maven.plugins.annotations.Mojo
@@ -28,8 +31,9 @@ class MuleDeployMojo extends BaseMojo {
 
     @Override
     void execute() throws MojoExecutionException, MojoFailureException {
-        if (dryRunMode != DryRunMode.OfflineValidate && !(anypointUsername || anypointPassword || anypointConnectedAppId || anypointConnectedAppSecret)) {
-            throw new Exception("In order to ${dryRunMode}, credentials must be supplied via the anypointUsername <config> item/anypoint.username property and the anypointPassword <config> item/anypoint.password property")
+        logger.println "DryRun Mode is set to " + dryRunMode
+        if (dryRunMode != DryRunMode.OfflineValidate) {
+            validateCredentials()
         }
         def deploymentPackage = processDsl()
         logger.println "Successfully processed ${groovyFile} through DSL"
@@ -38,17 +42,15 @@ class MuleDeployMojo extends BaseMojo {
             return
         }
         logger.println 'Beginning deployment'
-        def deployer = deployerFactory.create(this.anypointUsername,
-                                              this.anypointPassword,
-                                              this.anypointConnectedAppId,
-                                              this.anypointConnectedAppSecret,
+        Credential credential = new UsernamePasswordCredential(this.anypointUsername, this.anypointPassword)
+        if(this.anypointConnectedAppId != null && this.anypointConnectedAppSecret != null) {
+            credential = new ConnectedAppCredential(this.anypointConnectedAppId, this.anypointConnectedAppSecret)
+        }
+        def deployer = deployerFactory.create(credential,
                                               logger,
                                               this.dryRunMode,
                                               this.anypointOrganizationName,
                                               this.environmentsToDoDesignCenterDeploymentOn)
-        if (this.anypointUsername == null && this.anypointPassword == null && this.anypointConnectedAppId == null && this.anypointConnectedAppSecret == null) {
-            throw new Exception("Either anypoint.username and anypoint.password or anypoint.connected-app.id and anypoint.connected-app.secret must be defined.")
-        }
         try {
             deployer.deployApplication(deploymentPackage.deploymentRequest,
                                        deploymentPackage.apiSpecifications,
@@ -60,6 +62,21 @@ class MuleDeployMojo extends BaseMojo {
             logger.error("Unable to perform deployment because ${exception.class} ${exception.message}")
             throw new Exception('Unable to perform deployment',
                                 e)
+        }
+    }
+
+    void validateCredentials(){
+        String format = "%s Run ':help -Pdetail=true' goal for parameter details."
+        if((this.anypointUsername == null && this.anypointConnectedAppId == null) ||
+                (this.anypointUsername != null && this.anypointConnectedAppId != null)) {
+            throw new Exception(String.format(format, "Either (anypointUsername and anypointPassword) " +
+                    "or (anypointConnectedAppId and anypointConnectedAppSecret) must be defined."))
+        }
+        if(this.anypointUsername != null && this.anypointPassword == null) {
+            throw new Exception(String.format(format, "'anypointPassword' must be set when using 'anypointUsername'."))
+        }
+        if(this.anypointConnectedAppId != null && this.anypointConnectedAppSecret == null) {
+            throw new Exception(String.format(format, "'anypointConnectedAppSecret' must be set when using 'anypointConnectedAppId'."))
         }
     }
 }

--- a/maven-plugin/src/main/java/com/avioconsulting/mule/maven/MuleDeployMojo.groovy
+++ b/maven-plugin/src/main/java/com/avioconsulting/mule/maven/MuleDeployMojo.groovy
@@ -16,9 +16,9 @@ class MuleDeployMojo extends BaseMojo {
     private String anypointUsername
     @Parameter(property = 'anypoint.password')
     private String anypointPassword
-    @Parameter(property = 'anypoint.connected-app-id')
+    @Parameter(property = 'anypoint.connected-app.id')
     private String anypointConnectedAppId
-    @Parameter(property = 'anypoint.connected-app-secret')
+    @Parameter(property = 'anypoint.connected-app.secret')
     private String anypointConnectedAppSecret
     @Parameter(property = 'anypoint.org.name')
     private String anypointOrganizationName
@@ -47,7 +47,7 @@ class MuleDeployMojo extends BaseMojo {
                                               this.anypointOrganizationName,
                                               this.environmentsToDoDesignCenterDeploymentOn)
         if (this.anypointUsername == null && this.anypointPassword == null && this.anypointConnectedAppId == null && this.anypointConnectedAppSecret == null) {
-            throw new Exception("Either anypoint.username and anypoint.password or anypoint.connected-app-id and anypoint.connected-app-secret must be defined.")
+            throw new Exception("Either anypoint.username and anypoint.password or anypoint.connected-app.id and anypoint.connected-app.secret must be defined.")
         }
         try {
             deployer.deployApplication(deploymentPackage.deploymentRequest,

--- a/maven-plugin/src/test/java/com/avioconsulting/mule/maven/MuleDeployMojoTest.groovy
+++ b/maven-plugin/src/test/java/com/avioconsulting/mule/maven/MuleDeployMojoTest.groovy
@@ -5,6 +5,7 @@ import com.avioconsulting.mule.deployment.api.IDeployer
 import com.avioconsulting.mule.deployment.api.IDeployerFactory
 import com.avioconsulting.mule.deployment.api.ILogger
 import com.avioconsulting.mule.deployment.api.models.*
+import com.avioconsulting.mule.deployment.api.models.credentials.Credential
 import com.avioconsulting.mule.deployment.api.models.policies.Policy
 import org.apache.maven.artifact.DefaultArtifact
 import org.apache.maven.artifact.handler.ArtifactHandler
@@ -34,7 +35,8 @@ class MuleDeployMojoTest implements MavenInvoke {
     @Test
     void gets_correct_params() {
         // arrange
-        String actualUser, actualPass, actualConnectedAppId, actualConnectedAppSecret, actualOrg
+        String actualOrg
+        Credential actualCredential
         ILogger actualLogger
         DryRunMode actualDryRunMode
         List<String> actualEnvs
@@ -46,18 +48,12 @@ class MuleDeployMojoTest implements MavenInvoke {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
-                          String connectedAppId,
-                          String connectedAppSecret,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
                           List<String> environmentsToDoDesignCenterDeploymentOn ->
-                    actualUser = username
-                    actualPass = password
-                    actualConnectedAppId = connectedAppId
-                    actualConnectedAppSecret = connectedAppSecret
+                    actualCredential = credential
                     actualLogger = logger
                     actualDryRunMode = dryRunMode
                     actualEnvs = environmentsToDoDesignCenterDeploymentOn
@@ -82,6 +78,81 @@ muleDeploy {
                            dslText,
                            'the user',
                            'the pass',
+                    null,
+                null,
+                           // we don't want this thing to actually run
+                           DryRunMode.OnlineValidate,
+                           'the org',
+                           ['TST'])
+
+        // act
+        mojo.execute()
+
+        // assert
+        assertThat actualCredential.principal,
+                   is(equalTo('the user'))
+        assertThat actualCredential.username,
+                is(equalTo('the user'))
+        assertThat actualCredential.password,
+                   is(equalTo('the pass'))
+//        assertThat actualConnectedAppId,
+//                is(equalTo('the client'))
+//        assertThat actualConnectedAppSecret,
+//                is(equalTo('the secret'))
+        assertThat actualOrg,
+                   is(equalTo('the org'))
+        assertThat actualDryRunMode,
+                   is(equalTo(DryRunMode.OnlineValidate))
+        assertThat actualEnvs,
+                   is(equalTo(['TST']))
+    }
+
+    @Test
+    void gets_correct_params_connectedApp() {
+        // arrange
+        String actualOrg
+        Credential actualCredential
+        ILogger actualLogger
+        DryRunMode actualDryRunMode
+        List<String> actualEnvs
+        def mockDeployer = [
+                deployApplication: { FileBasedAppDeploymentRequest appDeploymentRequest,
+                                     ApiSpecificationList apiSpecification,
+                                     List<Policy> desiredPolicies,
+                                     List<Features> enabledFeatures ->
+                }
+        ] as IDeployer
+        def mock = [
+                create: { Credential credential,
+                          ILogger logger,
+                          DryRunMode dryRunMode,
+                          String anypointOrganizationName,
+                          List<String> environmentsToDoDesignCenterDeploymentOn ->
+                    actualCredential = credential
+                    actualLogger = logger
+                    actualDryRunMode = dryRunMode
+                    actualEnvs = environmentsToDoDesignCenterDeploymentOn
+                    actualOrg = anypointOrganizationName
+                    return mockDeployer
+                }
+        ] as IDeployerFactory
+        def dslText = """
+muleDeploy {
+    version '1.0'
+    
+    onPremApplication {
+        environment 'DEV'
+        applicationName 'the-app'
+        appVersion '1.2.3'
+        file '${builtFile}'
+        targetServerOrClusterName 'theServer'
+    }
+}
+"""
+        def mojo = getMojo(mock,
+                           dslText,
+                           null,
+                           null,
                            'the client',
                            'the secret',
                            // we don't want this thing to actually run
@@ -93,14 +164,16 @@ muleDeploy {
         mojo.execute()
 
         // assert
-        assertThat actualUser,
-                   is(equalTo('the user'))
-        assertThat actualPass,
-                   is(equalTo('the pass'))
-        assertThat actualConnectedAppId,
+        assertThat actualCredential.principal,
+                   is(equalTo('the client'))
+        assertThat actualCredential.id,
                 is(equalTo('the client'))
-        assertThat actualConnectedAppSecret,
-                is(equalTo('the secret'))
+        assertThat actualCredential.secret,
+                   is(equalTo('the secret'))
+//        assertThat actualConnectedAppId,
+//                is(equalTo('the client'))
+//        assertThat actualConnectedAppSecret,
+//                is(equalTo('the secret'))
         assertThat actualOrg,
                    is(equalTo('the org'))
         assertThat actualDryRunMode,
@@ -111,8 +184,8 @@ muleDeploy {
 
     MuleDeployMojo getMojo(IDeployerFactory mockDeployerFactory,
                            String groovyFileText,
-                           String user = 'our user',
-                           String pass = 'our pass',
+                           String user = null,
+                           String pass = null,
                            String connId = null,
                            String connSecret = null,
                            DryRunMode dryRunMode = DryRunMode.Run,
@@ -125,7 +198,7 @@ muleDeploy {
             it.anypointUsername = user
             it.anypointPassword = pass
             it.anypointConnectedAppId = connId
-            it.anypointConnectedAppId = connSecret
+            it.anypointConnectedAppSecret = connSecret
             it.dryRunMode = dryRunMode
             it.groovyFile = groovyFile
             it.anypointOrganizationName = orgName
@@ -154,8 +227,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -177,7 +249,9 @@ muleDeploy {
 }
 """
         def mojo = getMojo(mock,
-                           dslText)
+                           dslText,
+        'the user',
+        'the pass')
 
         // act
         mojo.execute()
@@ -298,7 +372,7 @@ muleDeploy {
         assertThat deployed,
                    is(equalTo(false))
         assertThat exception.message,
-                   is(containsString('In order to OnlineValidate, credentials must be supplied via the anypointUsername <config> item/anypoint.username property and the anypointPassword <config> item/anypoint.password property'))
+                   is(containsString('Either (anypointUsername and anypointPassword) or (anypointConnectedAppId and anypointConnectedAppSecret) must be defined. Run \':help -Pdetail=true\' goal for parameter details.'))
     }
 
     @Test
@@ -316,10 +390,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
-                          String connectedAppId,
-                          String ConnectedAppSecret,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -402,8 +473,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -425,7 +495,9 @@ muleDeploy {
 }
 """
         def mojo = getMojo(mock,
-                           dslText)
+                           dslText,
+                    'the user',
+                    'the pass')
         mojo.groovyFile = new File('foobar')
 
         // act
@@ -454,8 +526,7 @@ muleDeploy {
                 }
         ] as IDeployer
         def mock = [
-                create: { String username,
-                          String password,
+                create: { Credential credential,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -477,7 +548,9 @@ muleDeploy {
 }
 """
         def mojo = getMojo(mock,
-                           dslText)
+                           dslText,
+                'the user',
+                'the pass')
 
         // act
         def exception = shouldFail {

--- a/maven-plugin/src/test/java/com/avioconsulting/mule/maven/MuleDeployMojoTest.groovy
+++ b/maven-plugin/src/test/java/com/avioconsulting/mule/maven/MuleDeployMojoTest.groovy
@@ -34,7 +34,7 @@ class MuleDeployMojoTest implements MavenInvoke {
     @Test
     void gets_correct_params() {
         // arrange
-        String actualUser, actualPass, actualOrg
+        String actualUser, actualPass, actualConnectedAppId, actualConnectedAppSecret, actualOrg
         ILogger actualLogger
         DryRunMode actualDryRunMode
         List<String> actualEnvs
@@ -48,12 +48,16 @@ class MuleDeployMojoTest implements MavenInvoke {
         def mock = [
                 create: { String username,
                           String password,
+                          String connectedAppId,
+                          String connectedAppSecret,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
                           List<String> environmentsToDoDesignCenterDeploymentOn ->
                     actualUser = username
                     actualPass = password
+                    actualConnectedAppId = connectedAppId
+                    actualConnectedAppSecret = connectedAppSecret
                     actualLogger = logger
                     actualDryRunMode = dryRunMode
                     actualEnvs = environmentsToDoDesignCenterDeploymentOn
@@ -78,6 +82,8 @@ muleDeploy {
                            dslText,
                            'the user',
                            'the pass',
+                           'the client',
+                           'the secret',
                            // we don't want this thing to actually run
                            DryRunMode.OnlineValidate,
                            'the org',
@@ -91,6 +97,10 @@ muleDeploy {
                    is(equalTo('the user'))
         assertThat actualPass,
                    is(equalTo('the pass'))
+        assertThat actualConnectedAppId,
+                is(equalTo('the client'))
+        assertThat actualConnectedAppSecret,
+                is(equalTo('the secret'))
         assertThat actualOrg,
                    is(equalTo('the org'))
         assertThat actualDryRunMode,
@@ -103,6 +113,8 @@ muleDeploy {
                            String groovyFileText,
                            String user = 'our user',
                            String pass = 'our pass',
+                           String connId = null,
+                           String connSecret = null,
                            DryRunMode dryRunMode = DryRunMode.Run,
                            String orgName = null,
                            List<String> envs = ['DEV'],
@@ -112,6 +124,8 @@ muleDeploy {
         new MuleDeployMojo().with {
             it.anypointUsername = user
             it.anypointPassword = pass
+            it.anypointConnectedAppId = connId
+            it.anypointConnectedAppId = connSecret
             it.dryRunMode = dryRunMode
             it.groovyFile = groovyFile
             it.anypointOrganizationName = orgName
@@ -222,6 +236,8 @@ muleDeploy {
                            dslText,
                            null,
                            null,
+                           null,
+                           null,
                            DryRunMode.OfflineValidate)
         // act
         mojo.execute()
@@ -270,6 +286,8 @@ muleDeploy {
                            dslText,
                            null,
                            null,
+                           null,
+                           null,
                            DryRunMode.OnlineValidate)
         // act
         def exception = shouldFail {
@@ -300,6 +318,8 @@ muleDeploy {
         def mock = [
                 create: { String username,
                           String password,
+                          String connectedAppId,
+                          String ConnectedAppSecret,
                           ILogger logger,
                           DryRunMode dryRunMode,
                           String anypointOrganizationName,
@@ -349,6 +369,8 @@ muleDeploy {
                            dslText,
                            'user',
                            'pass',
+                           null,
+                           null,
                            DryRunMode.Run,
                            null,
                            ['DEV'],

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.avioconsulting.mule</groupId>
     <artifactId>mule-deploy-parent</artifactId>
-    <version>1.1.2</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <modules>
         <module>library</module>
-        <module>cli</module>
+<!--        <module>cli</module>-->
         <module>maven-plugin</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <modules>
         <module>library</module>
-<!--        <module>cli</module>-->
+        <module>cli</module>
         <module>maven-plugin</module>
     </modules>
 


### PR DESCRIPTION
Added connectedAppId/Secret as params to HTTP Wrapper and bubbled up through constructor calls and tests. Added additional function to handle connected app auth.

Added anypoint.connected-app.id and anypoint.connected-app.secret as plugin properties
Added --anypoint-connected-app-id (-caid) and --anypoint-connected-app-secret (-casec) as CLI params