### PR TITLE
chore: publish CLI jar to central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,28 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!--
+                        This project uses groovy to for development.
+                        The default maven-javadoc-plugin does not generate javadocs for groovy classes.
+                        maven-javadoc-plugin generates jars for library and maven-plugin due to the
+                        generated sources by apollo graphql plugin and help mojo java files.
+                        But CLI module does not have any java files so javadocs doesn't generate there.
+
+                        Adding groovydoc-maven-plugin to generate javadocs from groovy as well as java.
+                     -->
+                    <plugin>
+                        <groupId>com.bluetrainsoftware.maven</groupId>
+                        <artifactId>groovydoc-maven-plugin</artifactId>
+                        <version>2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-docs</id>
+                                <goals>
+                                    <goal>attach-docs</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
This project uses groovy to for development. The default maven-javadoc-plugin does not generate javadocs for groovy classes. maven-javadoc-plugin generates jars for library and maven-plugin due to the generated sources by apollo graphql plugin and help mojo java files. But CLI module does not have any java files so javadocs doesn't generate there. This error caused maven central publishing to fail for CLI jar. 

PR #54 skipped publishing CLI jar to Maven central for 1.2.0 version. For future releases, we may want to release CLI jar to central, in case any tooling needs to use the same class as CLI script to invoke the deployer. This provides the same validation to that integration as CLI script gets.

- [x] Fix java doc generation. (c0a2de176459bb15ea9fa2641759a24f35436d4d - Adding groovydoc-maven-plugin to generate javadocs from groovy as well as java.)
- [ ] Generate a shaded CLI jar?