### PR TITLE
chore: update version v1.2.1-SNAPSHOT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          branch: "feature/v${{ steps.set-new-version.outputs.version }}"
+          branch: "feat/v${{ steps.set-new-version.outputs.version }}"
           commit-message: "[create-pull-request] Auto increment to v${{ steps.set-new-version.outputs.version }}"
           title: "Auto increment to v${{ steps.set-new-version.outputs.version }}"
           delete-branch: true

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.avioconsulting.mule</groupId>
         <artifactId>mule-deploy-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.avioconsulting.mule</groupId>
         <artifactId>mule-deploy-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.avioconsulting.mule</groupId>
         <artifactId>mule-deploy-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.avioconsulting.mule</groupId>
     <artifactId>mule-deploy-parent</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Supercedes #55 with change in branch name to match actions pattern.

Auto-created version increment branch name was prefixed `feature/` instead of `feat/`. That prevented actions workflow to run on these branches. This PR corrects the workflow for the expected branch prefix.