### PR TITLE
chore: update jwt policy default version to 1.3.1

### DIFF
--- a/library/src/main/java/com/avioconsulting/mule/deployment/api/models/policies/JwtPolicy.groovy
+++ b/library/src/main/java/com/avioconsulting/mule/deployment/api/models/policies/JwtPolicy.groovy
@@ -23,7 +23,7 @@ class JwtPolicy extends MulesoftPolicy {
               Integer jwksCachingTtlInMinutes = null,
               String version = null) {
         super('jwt-validation',
-              version ?: '1.1.4',
+              version ?: '1.3.1',
               getConfig(jwksUrl,
                         expectedAudience,
                         expectedIssuer,

--- a/library/src/test/java/com/avioconsulting/mule/deployment/api/models/policies/AzureAdJwtPolicyTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/api/models/policies/AzureAdJwtPolicyTest.groovy
@@ -20,7 +20,7 @@ class AzureAdJwtPolicyTest {
         assertThat model.assetId,
                    is(equalTo('jwt-validation'))
         assertThat model.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
         assertThat model.policyConfiguration,
                    is(equalTo([
                            jwtOrigin             : 'httpBearerAuthenticationHeader',
@@ -62,7 +62,7 @@ class AzureAdJwtPolicyTest {
         assertThat model.assetId,
                    is(equalTo('jwt-validation'))
         assertThat model.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
         assertThat model.policyConfiguration,
                    is(equalTo([
                            jwtOrigin             : 'httpBearerAuthenticationHeader',
@@ -108,7 +108,7 @@ class AzureAdJwtPolicyTest {
         assertThat model.assetId,
                    is(equalTo('jwt-validation'))
         assertThat model.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
         assertThat model.policyConfiguration,
                    is(equalTo([
                            jwtOrigin             : 'httpBearerAuthenticationHeader',
@@ -157,7 +157,7 @@ class AzureAdJwtPolicyTest {
         assertThat model.assetId,
                    is(equalTo('jwt-validation'))
         assertThat model.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
         assertThat model.policyConfiguration,
                    is(equalTo([
                            jwtOrigin             : 'httpBearerAuthenticationHeader',
@@ -206,7 +206,7 @@ class AzureAdJwtPolicyTest {
         assertThat model.assetId,
                    is(equalTo('jwt-validation'))
         assertThat model.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
         assertThat model.policyConfiguration,
                    is(equalTo([
                            jwtOrigin             : 'httpBearerAuthenticationHeader',

--- a/library/src/test/java/com/avioconsulting/mule/deployment/api/models/policies/JwtPolicyTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/api/models/policies/JwtPolicyTest.groovy
@@ -22,7 +22,7 @@ class JwtPolicyTest {
         assertThat model.assetId,
                    is(equalTo('jwt-validation'))
         assertThat model.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
         assertThat model.policyConfiguration,
                    is(equalTo([
                            jwtOrigin             : 'httpBearerAuthenticationHeader',
@@ -90,7 +90,7 @@ class JwtPolicyTest {
         assertThat model.assetId,
                    is(equalTo('jwt-validation'))
         assertThat model.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
         assertThat model.policyConfiguration,
                    is(equalTo([
                            jwtOrigin             : 'httpBearerAuthenticationHeader',
@@ -143,7 +143,7 @@ class JwtPolicyTest {
         assertThat model.assetId,
                    is(equalTo('jwt-validation'))
         assertThat model.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
         assertThat model.policyConfiguration,
                    is(equalTo([
                            jwtOrigin             : 'httpBearerAuthenticationHeader',

--- a/library/src/test/java/com/avioconsulting/mule/deployment/dsl/policies/PolicyContextTest.groovy
+++ b/library/src/test/java/com/avioconsulting/mule/deployment/dsl/policies/PolicyContextTest.groovy
@@ -218,7 +218,7 @@ class PolicyContextTest {
         assertThat request,
                    is(instanceOf(JwtPolicy))
         assertThat request.version,
-                   is(equalTo('1.1.4'))
+                   is(equalTo('1.3.1'))
     }
 
     @Test


### PR DESCRIPTION
modified:   library/src/main/java/com/avioconsulting/mule/deployment/api/models/policies/JwtPolicy.groovy
modified:   library/src/test/java/com/avioconsulting/mule/deployment/api/models/policies/AzureAdJwtPolicyTest.groovy
modified:   library/src/test/java/com/avioconsulting/mule/deployment/api/models/policies/JwtPolicyTest.groovy
modified:   library/src/test/java/com/avioconsulting/mule/deployment/dsl/policies/PolicyContextTest.groovy