### PR TITLE
chore: Added sample custom policy configuration, and README tips

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -30,6 +30,12 @@ Option 2 is probably the preferred route for most use cases. Both options 2 and 
 
 You'll need a service account user/password to run this. See the README.md file inside the library directory for what permissions the user needs.
 
+## Custom Policies
+
+Most of the common security policies are accounted for in the DSL. A custom policy can be used for any additional options or customization that is necessary. For an example, see the `mulesoftPolicy` sample in `library/examples/allOptions.groovy`.
+
+To help populate the JSON config object of the desired custom policy, use the network inspector in chrome while manually configuring the policy.
+
 # Running
 
 If you read the DSL section, you should have a DSL file that's ready to go.

--- a/library/examples/allOptions.groovy
+++ b/library/examples/allOptions.groovy
@@ -47,7 +47,14 @@ muleDeploy {
             groupId 'stuff'
         }
         mulesoftPolicy {
-            version '1.2.1'
+            // Sample using the client id enforcement with header properties
+            assetId 'client-id-enforcement'
+            version '1.2.3'
+            config([
+                    credentialsOriginHasHttpBasicAuthenticationHeader: 'customExpression',
+                    clientIdExpression: '#[attributes.headers["client_id"]]',
+                    clientSecretExpression: '#[attributes.headers["client_secret"]]'
+            ])
         }
         azureAdJwtPolicy {
             azureAdTenantId 'abcd'


### PR DESCRIPTION
Was implementing client id enforcement with custom headers, and found this wasn't documented.