### PR TITLE
fix: pom artifact id param

### DIFF
--- a/maven-plugin/src/main/java/com/avioconsulting/mule/maven/BaseMojo.groovy
+++ b/maven-plugin/src/main/java/com/avioconsulting/mule/maven/BaseMojo.groovy
@@ -42,7 +42,7 @@ abstract class BaseMojo extends AbstractMojo {
             logger.println "Adding ${artifact.file} path as appArtifact in your DSL and setting groupId, artifactId and artifactVersion"
             props['appArtifact'] = artifact.file.absolutePath
             props['groupId'] = artifact.groupId
-            props['artifactId'] = artifact.id
+            props['artifactId'] = artifact.artifactId
             props['artifactVersion'] = artifact.version
         }
 


### PR DESCRIPTION
Maven artifact's `id` was set as an artifactId in the parameters. The `id` attributes has the value of Maven co-ordinates in the format -`groupId:artifactId:packaging:version`. This results in ApplicationName validation throwing a validation error since `:` is not allowed in the name. `artifact.artifactId` is the attribute that has intended value to be injected. This PR fixes it.